### PR TITLE
feat: add Telegram proxy support (#16)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,5 +36,8 @@ QDRANT_VECTOR_SIZE=1024
 ADMIN_IDS=125525685           # Telegram user IDs allowed to use /update
 LOG_LEVEL=INFO
 
+# Proxy (required on RU servers where Telegram is blocked)
+HTTPS_PROXY=                  # e.g. http://user:pass@host:3128
+
 # Deploy
 NODE_ENV=production

--- a/bot/main.py
+++ b/bot/main.py
@@ -6,6 +6,7 @@ import os
 import sys
 
 from aiogram import Bot, Dispatcher
+from aiogram.client.session.aiohttp import AiohttpSession
 from aiohttp import web
 from qdrant_client import AsyncQdrantClient
 
@@ -40,7 +41,12 @@ async def main() -> None:
     qdrant = AsyncQdrantClient(url=qdrant_url)
     logger.info("Qdrant client initialized: %s", qdrant_url)
 
-    bot = Bot(token=bot_token)
+    proxy_url = os.environ.get("HTTPS_PROXY") or os.environ.get("HTTP_PROXY")
+    if proxy_url:
+        logger.info("Using proxy: %s", proxy_url.split("@")[-1])
+        bot = Bot(token=bot_token, session=AiohttpSession(proxy=proxy_url))
+    else:
+        bot = Bot(token=bot_token)
     dp = Dispatcher()
     dp["qdrant"] = qdrant
 

--- a/bot/requirements.txt
+++ b/bot/requirements.txt
@@ -3,3 +3,4 @@ qdrant-client>=1.7.0
 httpx>=0.25.0
 asyncpg>=0.29.0
 aiohttp>=3.9.0
+aiohttp-socks>=0.8.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
       - EMBEDDING_MODEL=${EMBEDDING_MODEL:-intfloat/multilingual-e5-large}
       - LLM_MODEL=${LLM_MODEL:-google/gemini-2.0-flash-001}
+      - HTTPS_PROXY=${HTTPS_PROXY}
     depends_on:
       - qdrant
       - postgres


### PR DESCRIPTION
Closes #16

## Changes

- `bot/requirements.txt`: added `aiohttp-socks>=0.8.0` (required by aiogram for any proxy)
- `bot/main.py`: use `AiohttpSession(proxy=...)` when `HTTPS_PROXY` env var is set
- `.env.example`: documented `HTTPS_PROXY` variable
- `docker-compose.yml`: pass `HTTPS_PROXY` to bot service

## Deploy

After merge, rebuild and deploy:
```bash
cd /opt/energy-reglaments-bot
echo 'HTTPS_PROXY=http://ivan:ProxyLondon2443@100.69.177.71:3128' >> .env
docker compose build bot
docker compose up -d bot
```